### PR TITLE
Parameterize service and routes consistently

### DIFF
--- a/openshift/templates/nodejs.json
+++ b/openshift/templates/nodejs.json
@@ -15,7 +15,7 @@
       "kind": "Service",
       "apiVersion": "v1beta3",
       "metadata": {
-        "name": "nodejs-frontend",
+        "name": "${FRONTEND_SERVICE_NAME}",
         "creationTimestamp": null
       },
       "spec": {
@@ -29,7 +29,7 @@
           }
         ],
         "selector": {
-          "name": "nodejs-frontend"
+          "name": "${FRONTEND_SERVICE_NAME}"
         },
         "portalIP": "",
         "type": "ClusterIP",
@@ -43,14 +43,14 @@
       "kind": "Route",
       "apiVersion": "v1beta3",
       "metadata": {
-          "name": "frontend-route",
+          "name": "${FRONTEND_ROUTE}",
           "creationTimestamp": null
       },
       "spec": {
           "host" : "${FRONTEND_ROUTE}",
           "to": {
               "kind" : "Service",
-              "name" : "nodejs-frontend"
+              "name" : "${FRONTEND_SERVICE_NAME}"
           }
       }
     },
@@ -112,7 +112,7 @@
         "source": {
           "type": "Git",
           "git": {
-            "uri": "${GITHUB_URL}"
+            "uri": "${SOURCE_REPOSITORY_URL}"
           }
         },
         "strategy": {
@@ -141,7 +141,7 @@
       "kind": "DeploymentConfig",
       "apiVersion": "v1beta3",
       "metadata": {
-        "name": "nodejs-frontend",
+        "name": "nodejs-example",
         "creationTimestamp": null
       },
       "spec": {
@@ -172,13 +172,13 @@
         ],
         "replicas": 1,
         "selector": {
-          "name": "nodejs-frontend"
+          "name": "nodejs-example"
         },
         "template": {
           "metadata": {
             "creationTimestamp": null,
             "labels": {
-              "name": "nodejs-frontend"
+              "name": "nodejs-example"
             }
           },
           "spec": {
@@ -213,14 +213,19 @@
   "parameters": [
     {
       "name": "SOURCE_REPOSITORY_URL",
-      "description": "The URL with your Node.js application source code.",
+      "description": "The URL with your Node.js application source code",
       "value": "https://github.com/openshift/nodejs-ex.git"
     },
     {
+      "name": "FRONTEND_SERVICE_NAME",
+      "description": "Frontend service name",
+      "value": "nodejs"
+    },
+    {
       "name": "FRONTEND_ROUTE",
-      "description": "The exposed hostname that will route to the Node.js service.",
+      "description": "The exposed hostname that will route to the Node.js service",
       "value": "nodejs.apps"
-    }
+    }    
   ],
   "labels": {
     "template": "nodejs-example"


### PR DESCRIPTION
I went with a minimal set of parameters (service name and route) and derived other names (to avoid conflict) based on the service name.

I'm not 100% sure that line 231 should use the name of the template or the name of the service parameter.  Perhaps I need to add a 2nd parameter.

@bparees If you could review to make sure this is what instantapp templates should look like when being created multiple times in same project