### PR TITLE
execute tests against remote instance

### DIFF
--- a/tests/app_test.js
+++ b/tests/app_test.js
@@ -1,14 +1,16 @@
 var server   = require('../server'),
     chai     = require('chai'),
-    chaiHttp = require('chai-http'),
+    chaiHTTP = require('chai-http'),
     should   = chai.should();
 
-chai.use(chaiHttp);
+chai.use(chaiHTTP);
+
+reqServer = process.env.HTTP_TEST_SERVER || server
 
 describe('Basic routes tests', function() {
 
     it('GET to / should return 200', function(done){
-        chai.request(server)
+        chai.request(reqServer)
         .get('/')
         .end(function(err, res) {
             res.should.have.status(200);
@@ -18,7 +20,7 @@ describe('Basic routes tests', function() {
     })
 
     it('GET to /pagecount should return 200', function(done){
-        chai.request(server)
+        chai.request(reqServer)
         .get('/pagecount')
         .end(function(err, res) {
             res.should.have.status(200);


### PR DESCRIPTION
@tnozicka can you please git clone this and give it a try?
what you need is to export a variable HTTP_TEST_SERVER with your http://remoteinstance:port and the tests will be executed against that instance. Hope this helps, let me know.

@bparees PTAL.

done according to https://github.com/chaijs/chai-http#url

also i've tested this locally and it works.

fixes https://github.com/openshift/nodejs-ex/issues/59