### PR TITLE
Change DC strategy from Rolling to Recreate for DB templates

### DIFF
--- a/openshift/templates/nodejs-mongodb-persistent.json
+++ b/openshift/templates/nodejs-mongodb-persistent.json
@@ -154,7 +154,7 @@
       },
       "spec": {
         "strategy": {
-          "type": "Rolling"
+          "type": "Recreate"
         },
         "triggers": [
           {

--- a/openshift/templates/nodejs-mongodb.json
+++ b/openshift/templates/nodejs-mongodb.json
@@ -154,7 +154,7 @@
       },
       "spec": {
         "strategy": {
-          "type": "Rolling"
+          "type": "Recreate"
         },
         "triggers": [
           {


### PR DESCRIPTION
Recreate strategy will allow the redeployment process to stay within
1Gi memory limit instead of requiring more memory due to extra pod
is created for Rolling strategy.

Signed-off-by: Vu Dinh <vdinh@redhat.com>