### PR TITLE
Revert "Changed templates to use nodejs:6"

### DIFF
--- a/openshift/templates/nodejs-mongodb-persistent.json
+++ b/openshift/templates/nodejs-mongodb-persistent.json
@@ -102,7 +102,7 @@
             "from": {
               "kind": "ImageStreamTag",
               "namespace": "${NAMESPACE}",
-              "name": "nodejs:6"
+              "name": "nodejs:4"
             },
             "env":  [
               {

--- a/openshift/templates/nodejs-mongodb.json
+++ b/openshift/templates/nodejs-mongodb.json
@@ -102,7 +102,7 @@
             "from": {
               "kind": "ImageStreamTag",
               "namespace": "${NAMESPACE}",
-              "name": "nodejs:6"
+              "name": "nodejs:4"
             },
             "env": [
               {

--- a/openshift/templates/nodejs.json
+++ b/openshift/templates/nodejs.json
@@ -89,7 +89,7 @@
             "from": {
               "kind": "ImageStreamTag",
               "namespace": "${NAMESPACE}",
-              "name": "nodejs:6"
+              "name": "nodejs:4"
             },
             "env":  [
               {


### PR DESCRIPTION
Reverts openshift/nodejs-ex#111

this needs to be reverted until the centos imagestream is available.
