### PR TITLE
Update GA for support the latest NodeJS versions.

### DIFF
--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "18-ubi8", "20-ubi8", "18-ubi9", "20-ubi9", "22-ubi9" ]
+        version: [ "20-ubi8", "22-ubi8", "20-ubi9", "22-ubi9", "22-ubi10" ]
 
     if: |
       github.event.issue.pull_request
@@ -20,7 +20,7 @@ jobs:
       - uses: sclorg/testing-farm-as-github-action@main
         with:
           api_key: ${{ secrets.TF_INTERNAL_API_KEY }}
-          compose: "RHEL-9.4.0-Nightly"
+          compose: "RHEL-9.6.0-Nightly"
           git_url: "https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
           git_ref: "master"
           tf_scope: "private"


### PR DESCRIPTION
Move compose to RHEL-9.6.0-Nighlty


